### PR TITLE
Ansible 2.2 fix

### DIFF
--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -56,6 +56,6 @@
 
 - name: copy other monit config files from playbook's, if any
   template: src={{ playbook_dir }}/{{ item.value.src }}  dest={{ monit_config_path }}/{{ item.value.dest }}
-  with_dict: monit_conf_others | default({})
+  with_dict: "{{ monit_conf_others | default({}) }}"
   notify:
     - restart monit


### PR DESCRIPTION
Hi!
Since ansible v2.2, with_dict variable must be templated.

Here is the quote from the changelog :

> with_ 'bare variable' handling, now loop items must always be templated {{ }} or they will be considered as plain strings.